### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 To install `et_replay`, use the following commands:
 
 ```bash
-$ git clone https://github.com/pytorch-labs/chakra_replay/
+$ git clone https://github.com/meta-pytorch/chakra_replay/
 $ conda create -n et_replay python=3.10
 $ conda activate et_replay
 $ cd chakra_replay


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:27:29.819207+00:00Z