### PR TITLE
Support coalesced collectives in comm replay

### DIFF
--- a/et_replay/comm/backend/pytorch_dist_backend.py
+++ b/et_replay/comm/backend/pytorch_dist_backend.py
@@ -26,11 +26,6 @@ import torch.nn as nn
 from torch._C._distributed_c10d import (
     AllgatherOptions,
     AllreduceCoalescedOptions,
-    AllreduceOptions,
-    AllToAllOptions,
-    BarrierOptions,
-    BroadcastOptions,
-    ReduceOptions,
     ReduceScatterOptions,
 )
 
@@ -418,16 +413,8 @@ class PyTorchDistBackend(BaseBackend):
         if self.use_ext_dist:
             raise NotImplementedError("allgather_into_tensor_coalesced is not implemented when use_ext_dist is true")
         else:
-            opTensor=(
-                collectiveArgs.opTensor
-                if not pair
-                else collectiveArgs.opTensor_pair
-            ),
-            ipTensor=(
-                collectiveArgs.ipTensor
-                if not pair
-                else collectiveArgs.ipTensor_pair
-            ),
+            opTensor =collectiveArgs.opTensor if not pair else collectiveArgs.opTensor_pair
+            ipTensor=collectiveArgs.ipTensor if not pair else collectiveArgs.ipTensor_pair
             group=self.get_collective_group(collectiveArgs)
             all_gather_opts = AllgatherOptions()
             all_gather_opts.asyncOp = collectiveArgs.asyncOp

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -207,7 +207,11 @@ def _parse_comms_op_node(  # noqa: C901
         if not comm_args.worldSize:
             # if no pg info provided, use total ranks as world size
             comm_args.worldSize = total_ranks
-        if comm_args.comms == "all_to_all":
+        if comm_args.comms in (
+            "all_to_all", 
+            "allgather_into_tensor_coalesced", 
+            "reduce_scatter_tensor_coalesced", 
+            "allreduce_coalesced") :
             # flatten each tensor and store the # of elements into split field
             comm_args.inSplit = [math.prod(i) for i in node.input_shapes[0]]
             comm_args.outSplit = [math.prod(i) for i in node.output_shapes[0]]

--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -1316,6 +1316,8 @@ class paramCommsBench(ABC):
         ipTensor = torch.Tensor()
 
         dispatchDict = {
+            "allgather_into_tensor_coalesced": self._prep_allgather_into_tensor_coalesced,
+            "allreduce_coalesced": self._prep_allreduce_coalesced,
             "all_to_allv": self._prep_all_to_allv,
             "all_to_all": self._prep_all_to_all,
             "all_gather": self._prep_all_gather,
@@ -1323,6 +1325,7 @@ class paramCommsBench(ABC):
             "all_gather_base": self._prep_all_gather_base,
             "reduce_scatter": self._prep_reduce_scatter,
             "reduce_scatter_base": self._prep_reduce_scatter_base,
+            "reduce_scatter_tensor_coalesced": self._prep_reduce_scatter_tensor_coalesced,
             "scatter": self._prep_reduce_scatter,
             "pt2pt": self._prep_pt2pt,
         }

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -689,9 +689,6 @@ class commsTraceReplayBench(paramCommsBench):
         commsParams: commsParamsHolderBase,
         regenerateTensors: bool,
     ) -> tuple[torch.Tensor, list[torch.Tensor] | torch.Tensor]:
-        # Use exactly specified inMsgSize/outMsgSize if call from trace replay
-        # This avoid regenerating sizes such as in _prep_all_gather_base
-        commsParams.size_from_trace = True
         commsParams.dtype = self.dtypeMap[curComm.dtype]
         if self.data_accuracy_checkmode:
             commsOpHash = curComm.id


### PR DESCRIPTION
Charka comm replay missed three coalesced collectives: allgather_into_tensor_coalesced, reduce_scatter_tensor_coalesced, allreduce_coalesced. These collectives are being used in Megatron Llama4. This PR is to add the support of these collectives in comm replay.

I also cleaned up some code in allocating tensors for collectives. Some ops will double allocate the tensors. 